### PR TITLE
Add `edit video` dropdown to user profile page

### DIFF
--- a/frontend/src/components/button.vue
+++ b/frontend/src/components/button.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { useAttrs } from "vue";
+import { computed, useAttrs } from "vue";
 
 defineOptions({
   inheritAttrs: false,
@@ -32,27 +32,29 @@ const props = withDefaults(defineProps<Props>(), {
   padding: "normal",
 });
 
-const themeColors: Colors = {
-  ...{
-    blue: {
-      default: "bg-frost-blue",
-      hover: "hover:bg-frost-deep",
-    },
-    red: {
-      default: "bg-aurora-red",
-      hover: "hover:bg-aurora-red-700",
-    },
-    purple: {
-      default: "bg-aurora-purple",
-      hover: "hover:bg-aurora-purple-700",
-    },
-    invisible: {
-      default: "bg-transparent",
-      hover: "hover:bg-polar-light",
-    },
-  }[props.theme],
-  ...props.colors,
-};
+const themeColors = computed<Colors>(() => {
+  return {
+    ...{
+      blue: {
+        default: "bg-frost-blue",
+        hover: "hover:bg-frost-deep",
+      },
+      red: {
+        default: "bg-aurora-red",
+        hover: "hover:bg-aurora-red-700",
+      },
+      purple: {
+        default: "bg-aurora-purple",
+        hover: "hover:bg-aurora-purple-700",
+      },
+      invisible: {
+        default: "bg-transparent",
+        hover: "hover:bg-polar-light",
+      },
+    }[props.theme],
+    ...props.colors,
+  };
+});
 </script>
 
 <template lang="pug">

--- a/frontend/src/components/content-grid/preview/generic.vue
+++ b/frontend/src/components/content-grid/preview/generic.vue
@@ -1,22 +1,34 @@
 <script setup lang="ts">
-import type { RouteLocationRaw } from "vue-router";
+import { computed, defineProps, withDefaults } from "vue";
+import type { RouteLocationNamedRaw, RouteLocationRaw } from "vue-router";
 import CAnchorCover from "@/components/anchor/cover.vue";
 import CAnchorRoot from "@/components/anchor/root.vue";
+import CButton from "@/components/button.vue";
+import CDropdown from "@/components/dropdown/dropdown.vue";
+import CDropdownItem from "@/components/dropdown/item.vue";
 import CIcon from "@/components/icon.vue";
 import type { User } from "@/endpoints/user";
 import { dateToElapsedTimeString, secsToDurationString } from "@/utils/strings";
 
-defineProps<{
-  link: RouteLocationRaw;
-  thumbnailUrl: string;
-  durationSecs: number;
-  name: string;
-  creator: User;
-  beginAt: Date;
-  viewership: number;
-  viewershipName: string;
-  icon?: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    link: RouteLocationRaw;
+    thumbnailUrl: string;
+    durationSecs: number;
+    name: string;
+    creator: User;
+    beginAt: Date;
+    viewership: number;
+    viewershipName: string;
+    icon?: string;
+    kebabMenu?: boolean;
+  }>(),
+  { icon: undefined, kebabMenu: false },
+);
+
+const videoId = computed(() => {
+  return `${(props.link as RouteLocationNamedRaw)?.params?.id?.toString() ?? props.link}`;
+});
 </script>
 
 <template lang="pug">
@@ -39,5 +51,15 @@ c-anchor-root.group.w-full(class="max-w-[416px]")
         | {{ viewership }} {{ viewershipName + (viewership === 1 ? '' : 's') }}
         | •
         | {{ dateToElapsedTimeString(beginAt) }}
-    c-icon.text-slate-300(v-if="icon" :name="icon")
+    .flex.flex-col.justify-between.items-center
+      template(v-if="kebabMenu")
+        c-dropdown.flex.justify-center(class="[&_>_ul]:w-fit [&_>_ul]:right-0 [&_>_ul]:top-full")
+          c-dropdown-item(class="[&_>_li]:!bg-frost-blue hover:[&_>_li]:!bg-frost-deep")
+            router-link.block(:to="{ name: 'edit', params: { videoId: videoId } }")
+              span Edit video
+              c-anchor-cover
+
+          template(#button="{ toggled }")
+            c-button.text-xl(class="!p-0 !px-2" :theme="toggled ? 'blue' : 'invisible'") ⋮
+      c-icon.text-slate-300(v-if="icon" :name="icon")
 </template>

--- a/frontend/src/views/user.vue
+++ b/frontend/src/views/user.vue
@@ -60,5 +60,5 @@ c-empty-collection(
   text-margin
 )
   c-tile-grid
-    c-user-video-preview(v-for="video of videos" :show-visibility="isPersonalPage" :video="video")
+    c-user-video-preview(v-for="video of videos" :show-visibility="isPersonalPage" :video="video" kebabMenu)
 </template>


### PR DESCRIPTION
This feature allows the user to navigate to the edit page without having to change the URL.

Changes made:
`./button.vue` component:
- Use's a computed ref for theme colours to allow a dynamic/runtime change of theme.

`./generic.vue` (video) component:
- Added a flex container to hold visibility Icon & dropdown. 
- Dropdown menu was added which contains `edit video` page navigation
- Dropdown uses arbitrary tailwind selectors to override hard coded styles in components.